### PR TITLE
Fix for adding a todo item

### DIFF
--- a/app/src/main/java/com/candy/todoproductivityapp/AddOrUpdateTodoActivity.java
+++ b/app/src/main/java/com/candy/todoproductivityapp/AddOrUpdateTodoActivity.java
@@ -26,7 +26,9 @@ public class AddOrUpdateTodoActivity extends AppCompatActivity {
     Button btnCancelTodo;
 
     private int currentId;
-    private TodoHelper todoHelper;
+
+    // It is not possible to pass an object to an Activity, so this has to be static.
+    public static TodoHelper todoHelper;
 
     /**
      *
@@ -53,7 +55,6 @@ public class AddOrUpdateTodoActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_add_or_update_todo);
-        todoHelper = new TodoHelper(getApplicationContext());
         initView();
         bindData();
 

--- a/app/src/main/java/com/candy/todoproductivityapp/TodoHelper.java
+++ b/app/src/main/java/com/candy/todoproductivityapp/TodoHelper.java
@@ -37,7 +37,7 @@ public class TodoHelper {
 
 
     // * get content stored on disk (tell Gson to convert list of todos)
-    public List<TodoModel> getFromDisk() {
+    public void getFromDisk() {
         Gson gson = new Gson();
         String json = sharedPreferences.getString(KEY_LIST, null);
 
@@ -45,7 +45,12 @@ public class TodoHelper {
         }.getType();
 
         list = gson.fromJson(json, type);
-        return list == null ? new ArrayList<>() : new ArrayList<>(list) ;
+
+        // The list will be null when there is not existing data (or it's mangled). So start with an
+        // empty list in that case.
+        if (list == null) {
+            list = new ArrayList<>();
+        }
     }
 
     /**

--- a/app/src/main/java/com/candy/todoproductivityapp/TodosRecyclerViewActivity.java
+++ b/app/src/main/java/com/candy/todoproductivityapp/TodosRecyclerViewActivity.java
@@ -17,10 +17,6 @@ import java.util.List;
 import uber.candy.todo.model.TodoModel;
 
 public class TodosRecyclerViewActivity extends AppCompatActivity {
-
-    private TodosRecyclerViewAdapter adapter;
-    private TodoHelper toDoHelper;
-
     Button btnAdd;
 
     @Override
@@ -28,8 +24,8 @@ public class TodosRecyclerViewActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_todos_recycler_view);
 
-        toDoHelper = new TodoHelper(getApplicationContext());
-        List<TodoModel> list = toDoHelper.getFromDisk();
+        TodoHelper toDoHelper = new TodoHelper(getApplicationContext());
+        toDoHelper.getFromDisk();
 
         btnAdd = findViewById(R.id.btn_add_todo);
         btnAdd.setOnClickListener(v -> addNewTodo());
@@ -37,15 +33,15 @@ public class TodosRecyclerViewActivity extends AppCompatActivity {
         RecyclerView todosRecyclerView = findViewById(R.id.rv_todo_list_items);
         todosRecyclerView.setHasFixedSize(true);
 
-        Toast.makeText(this,"Todo Count: " + list.size(), Toast.LENGTH_SHORT).show();
+        Toast.makeText(this,"Todo Count: " + toDoHelper.list.size(), Toast.LENGTH_SHORT).show();
 
         RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(this);
         todosRecyclerView.setLayoutManager(layoutManager);
 
-        adapter = new TodosRecyclerViewAdapter(list, this);
-        todosRecyclerView.setAdapter(adapter);
+        toDoHelper.adapter = new TodosRecyclerViewAdapter(toDoHelper.list, this);
+        todosRecyclerView.setAdapter(toDoHelper.adapter);
 
-
+        AddOrUpdateTodoActivity.todoHelper = toDoHelper;
     }
 
     /**


### PR DESCRIPTION
When adding a new item it would not show in the list. This was because
there was two TodoHelper instances. One that belonged to the
TodosRecyclerViewActivity and another one created in
AddOrUpdateTodoActivity. So when we added a new todo it was adding it to
the latter instead of the former.

However, we could see the new todo when relaunching the app because in
both cases the todo was saved so it was restored by
TodosRecyclerViewActivity. The solution is to make sure there is only
one TodoHelper which manages the only list of todos. Updating the todo
list isn't magic, we still need to use notifyDataSetChanged() for the
UI.

This also fixes a bug where the first ever load (when there are no
todos) would cause the app to crash because theres no JSON to parse.